### PR TITLE
Pull Request: Improve Documentation and Add Options passing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 sudo: false
 node_js:
+  - "12"
+  - "10"
   - "8"
-  - "6"
   - "node"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Installing
 
-```
+```sh
 npm install @mother/socket.io-adapter-mongo --save
 ```
 
@@ -14,6 +14,20 @@ npm install @mother/socket.io-adapter-mongo --save
 const io = require('socket.io')(3000);
 const mongoAdapter = require('@mother/socket.io-adapter-mongo');
 io.adapter(mongoAdapter('mongodb://localhost/test'));
+```
+
+or pass an object
+
+```js
+const io = require("socket.io")(3000);
+const mongoAdapter = require("@mother/socket.io-adapter-mongo");
+io.adapter(mongoAdapter({
+	uri: "mongodb://localhost/test",
+	key: "socket.io",
+	mOptions: {
+		tls: true
+	}
+	}));
 ```
 
 By running socket.io with the `socket.io-adapter-mongo` adapter you can run
@@ -27,16 +41,32 @@ process, you should use [socket.io-emitter](https://github.com/socketio/socket.i
 
 ### adapter(uri[, opts])
 
-`uri` is a a mongodb:// uri. For a list of options see below.
+`uri` is a a mongodb:// uri string
+
+If using this method of calling the adapter, the uri string will used instead of the uri property in the options object.
+
+For a list of options see below.
 
 ### adapter(opts)
 
 The following options are allowed:
 
+- `uri`: mongodb:// uri string this property or the `mongoose` property are **required**.
 - `key`: the name of the key to pub/sub events on as prefix (`socket.io`)
 - `collectionName`: the name of the capped collection to be used (`socket.io-message-queue`)
 - `collectionSize`: the size of the capped collection to be used, in bytes (`1000000`) (10mb)
-- `mongoose`: an existing mongoose instance that can be used instead of a mongodb:// uri
+- `mongoose`: an existing Mongoose instance that can be used instead of a mongodb:// uri
+- `mOptions`: options to pass to Mongoose
+
+## Notes
+
+The following options are passed to Mongoose by default:
+
+- `useNewUrlParser`: true
+- `useUnifiedTopology`: true
+- `autoReconnect`: true
+
+If you want to override these options, just include them in `mOptions`.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,6 @@ The following options are passed to Mongoose by default:
 
 - `useNewUrlParser`: true
 - `useUnifiedTopology`: true
-- `autoReconnect`: true
 
 If you want to override these options, just include them in `mOptions`.
 

--- a/index.js
+++ b/index.js
@@ -887,6 +887,20 @@ module.exports = function adapter(uriArg, optionsArg = {}) {
       ? uriArg.uri
       : uriArg
 
+   const mongooseOptions = typeof options === 'object' && options.mOptions
+      ? Object.assign(
+         {
+            useNewUrlParser: true,
+            useUnifiedTopology: true,
+            autoReconnect: true
+         },
+         options.mOptions
+      )
+      : {
+         useNewUrlParser: true,
+         useUnifiedTopology: true,
+         autoReconnect: true
+      }
    const prefix = options.key || 'socket.io'
    const requestsTimeout = options.requestsTimeout || 5000
    const heartbeatInterval = options.heartbeatInterval || 1000
@@ -895,7 +909,7 @@ module.exports = function adapter(uriArg, optionsArg = {}) {
    const collectionSize = options.collectionSize || 100000 // 100KB
    const mongoose = options.mongoose || new Mongoose()
    if (!options.mongoose && uri) {
-      mongoose.connect(uri, {useNewUrlParser: true, useUnifiedTopology: true})
+      mongoose.connect(uri, mongooseOptions)
    }
 
    // mongoose.set('debug', true)

--- a/index.js
+++ b/index.js
@@ -891,15 +891,13 @@ module.exports = function adapter(uriArg, optionsArg = {}) {
       ? Object.assign(
          {
             useNewUrlParser: true,
-            useUnifiedTopology: true,
-            autoReconnect: true
+            useUnifiedTopology: true
          },
          options.mOptions
       )
       : {
          useNewUrlParser: true,
-         useUnifiedTopology: true,
-         autoReconnect: true
+         useUnifiedTopology: true
       }
    const prefix = options.key || 'socket.io'
    const requestsTimeout = options.requestsTimeout || 5000

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mother/socket.io-adapter-mongo",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "socket.io adapter for MongoDB",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
This pull adds an additional example to the documentation and additional information.  It also adds the ability to pass options to Mongoose / mongodb.

This also adds node 10 and 12 to Travis and removed node 6 which is end of life.